### PR TITLE
Make Node 0.10 EOL official?

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <th>Maintenance End</th>
 </tr>
 <tr>
-  <td><b>Maintenance</b></td>
+  <td><b>EOL</b></td>
   <td>v0.10</td>
   <td>-</td>
   <td>2015-10-01</td>


### PR DESCRIPTION
Hey folks! 

I'm not sure if you want to leave v0.10 in the table marked EOL for a while or if this should now be removed.

I'm raising this PR more as a place to clarify - v0.10 support ended yesterday but there wasn't any messaging on blog.nodejs.org. I had thought the discussion in the last meeting ended with an agreement that there was going to be more messaging. However, I do realise that it is time-consuming to do. 

Is there anything I can do to help?